### PR TITLE
Skip duplicates and persist content only

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
         try {
           const res = await fetch('/next');
           if (!res.ok) {
-            document.getElementById('content').textContent = 'No more messages';
+            document.getElementById('content').textContent = 'Waiting for more messages...';
             current = null;
             poll = setTimeout(() => getNext(enterDir), 3000);
             return;


### PR DESCRIPTION
## Summary
- omit `id` and `timestamp` fields when persisting `data.json`
- auto-skip and label duplicate messages
- show "Waiting for more messages..." when nothing to label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c522d9448329955b1efe2d6ec3a9