### PR TITLE
Enhance moderator UI with user details

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -31,7 +31,11 @@ client.on('messageCreate', async (msg) => {
     id: msg.id,
     content: msg.content,
     timestamp: msg.createdAt.toISOString(),
-    authorId: msg.author.id
+    authorId: msg.author.id,
+    username: msg.author.username,
+    displayName: msg.member ? msg.member.displayName : msg.author.username,
+    avatar: msg.author.displayAvatarURL({ extension: 'png', size: 64 }),
+    roles: msg.member ? msg.member.roles.cache.filter(r => r.name !== '@everyone').map(r => r.name) : []
   };
   await postQueue(payload);
 });

--- a/public/index.html
+++ b/public/index.html
@@ -12,30 +12,61 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
+      background-color: #222;
+      color: #eee;
       transition: background-color 0.3s;
     }
 
     #box {
-      border: 1px solid #ccc;
+      border: 1px solid #444;
       padding: 20px;
       border-radius: 8px;
       min-width: 300px;
       text-align: center;
       font-size: 1.5em;
+      background-color: #333;
       transition: transform 0.3s;
+    }
+
+    #author {
+      display: flex;
+      align-items: center;
+      margin-bottom: 10px;
+    }
+
+    #author img {
+      width: 48px;
+      height: 48px;
+      border-radius: 24px;
+      margin-right: 10px;
+    }
+
+    #roles {
+      font-size: 0.7em;
+      color: #aaa;
     }
 
     #controls { margin-top: 20px; }
     #controls > div { margin-top: 5px; }
     #controls > div { display: flex; justify-content: center; }
 
-    .flash-green { background-color: #cfc; }
-    .flash-red { background-color: #fcc; }
-    .flash-blue { background-color: #ccf; }
+    .flash-green { background-color: #264d26; }
+    .flash-red { background-color: #4d2626; }
+    .flash-blue { background-color: #26324d; }
   </style>
 </head>
   <body>
-    <div id="box"><div id="content">Loading...</div></div>
+    <div id="box">
+      <div id="author">
+        <img id="avatar" src="" alt="avatar">
+        <div>
+          <div id="username"></div>
+          <div id="displayName" style="font-size:0.9em;color:#bbb"></div>
+          <div id="roles"></div>
+        </div>
+      </div>
+      <div id="content">Loading...</div>
+    </div>
     <div id="controls">
       <div><button id="mute15Btn">Mute 15m (↑)</button></div>
       <div>
@@ -56,6 +87,10 @@
           const res = await fetch('/next');
           if (!res.ok) {
             document.getElementById('content').textContent = 'Waiting for more messages...';
+            document.getElementById('username').textContent = '';
+            document.getElementById('displayName').textContent = '';
+            document.getElementById('roles').textContent = '';
+            document.getElementById('avatar').src = '';
             current = null;
             poll = setTimeout(() => getNext(enterDir), 3000);
             return;
@@ -69,6 +104,10 @@
           void box.offsetWidth;
           box.style.transition = 'transform 0.3s';
           document.getElementById('content').textContent = current.content || '[no content]';
+          document.getElementById('username').textContent = current.username || '';
+          document.getElementById('displayName').textContent = current.displayName || '';
+          document.getElementById('roles').textContent = (current.roles && current.roles.length) ? current.roles.join(', ') : '';
+          document.getElementById('avatar').src = current.avatar || '';
           box.style.transform = 'translateX(0)';
         } catch (e) {
           console.error(e);
@@ -106,6 +145,10 @@
         }
         current = await res.json();
         document.getElementById('content').textContent = current.content || '[no content]';
+        document.getElementById('username').textContent = current.username || '';
+        document.getElementById('displayName').textContent = current.displayName || '';
+        document.getElementById('roles').textContent = (current.roles && current.roles.length) ? current.roles.join(', ') : '';
+        document.getElementById('avatar').src = current.avatar || '';
       }
 
       document.getElementById('unsafeBtn').onclick = () => sendLabel('unsafe');

--- a/server.js
+++ b/server.js
@@ -22,7 +22,11 @@ function loadData() {
       label: item.label,
       sourceId: item.sourceId,
       timestamp: item.timestamp,
-      authorId: item.authorId
+      authorId: item.authorId,
+      username: item.username,
+      displayName: item.displayName,
+      avatar: item.avatar,
+      roles: item.roles
     }));
   } catch (e) {
     return [];
@@ -35,7 +39,11 @@ function saveData(data) {
     label: item.label,
     sourceId: item.sourceId,
     timestamp: item.timestamp,
-    authorId: item.authorId
+    authorId: item.authorId,
+    username: item.username,
+    displayName: item.displayName,
+    avatar: item.avatar,
+    roles: item.roles
   }));
   fs.writeFileSync(DATA_FILE, JSON.stringify(stripped, null, 2));
 }
@@ -44,7 +52,7 @@ let queue = loadData();
 let nextId = queue.reduce((max, m) => Math.max(max, m.id), 0) + 1;
 
 app.post('/queue', (req, res) => {
-  const { id: sourceId, content, timestamp, authorId } = req.body || {};
+  const { id: sourceId, content, timestamp, authorId, username, displayName, avatar, roles } = req.body || {};
   if (!sourceId || !timestamp) {
     return res.status(400).json({ error: 'invalid payload' });
   }
@@ -56,7 +64,7 @@ app.post('/queue', (req, res) => {
   const existing = queue.find(m => m.label && m.content === content);
   if (existing) label = existing.label;
 
-  const item = { id: nextId++, sourceId, content, timestamp, authorId };
+  const item = { id: nextId++, sourceId, content, timestamp, authorId, username, displayName, avatar, roles };
   if (label) item.label = label;
   queue.push(item);
   try {
@@ -83,7 +91,14 @@ function getNextItem() {
 app.get('/next', (req, res) => {
   const item = getNextItem();
   if (!item) return res.status(404).end();
-  res.json({ id: item.id, content: item.content });
+  res.json({
+    id: item.id,
+    content: item.content,
+    username: item.username,
+    displayName: item.displayName,
+    avatar: item.avatar,
+    roles: item.roles
+  });
 });
 
 app.post('/jump', (req, res) => {
@@ -101,7 +116,14 @@ app.post('/jump', (req, res) => {
   } catch (e) {
     console.error('Failed to save data:', e);
   }
-  res.json({ id: last.id, content: last.content });
+  res.json({
+    id: last.id,
+    content: last.content,
+    username: last.username,
+    displayName: last.displayName,
+    avatar: last.avatar,
+    roles: last.roles
+  });
 });
 
 async function deleteMessage(id) {


### PR DESCRIPTION
## Summary
- add user info to queue payload from Discord
- persist username, display name, avatar, and roles on the server
- return those fields via `/next` and `/jump`
- overhaul front-end with dark theme
- display avatar, username, display name, and roles next to each message

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859cc2bf2f483298962fd0936e6acbf