### PR TITLE
Update help menu for mute actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -95,10 +95,10 @@
     <div id="helpContainer">
       <button id="helpBtn">?</button>
       <div id="helpMenu">
-        <div><b>Mute 15m (↑)</b> - mute user for 15 minutes</div>
         <div><b>Unsafe (←)</b> - delete and mark message unsafe</div>
         <div><b>Safe (→)</b> - mark message as safe</div>
-        <div><b>Mute 5m (↓)</b> - mute user for 5 minutes</div>
+        <div><b>Mute 5m (↓)</b> - mute user for 5 minutes and delete the message</div>
+        <div><b>Mute 15m (↑)</b> - mute user for 15 minutes and delete the message</div>
         <div><b>Jump to Present</b> - skip to most recent message</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update help menu wording to note that mute actions delete messages
- reorder help items as requested

## Testing
- `npm test` *(fails: cannot find module 'express' / missing config)*

------
https://chatgpt.com/codex/tasks/task_e_6859d0d57a44832994a5345c2970a58c