### PR TITLE
Fix queue polling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -258,7 +258,7 @@
           if (!m) break;
           addTab(m, true);
         }
-        if (queue.length === 0) poll = setTimeout(ensureQueue, 3000);
+        poll = setTimeout(ensureQueue, 3000);
       }
 
       async function sendLabel(label, minutes) {


### PR DESCRIPTION
## Summary
- fix polling in `ensureQueue` to fetch new messages while the queue is not empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859e285af548329a76a65f54ab4c45c