### PR TITLE
Add IP logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This prototype collects Discord messages and lets you label them as `safe` or `u
    ```
 2. Copy `config.example.json` to `config.json` and fill in your Discord bot token, channel ID and guild ID.
 3. Copy `whitelist.example.json` to `whitelist.json` and list the IP addresses allowed to access the site.
+   If requests are blocked, check the server console for lines starting with `IP:`
+   to see the address being checked and add it to the whitelist.
 4. Start the web server:
    ```bash
    npm run server

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ app.use((req, res, next) => {
   let ip = forwarded ? forwarded.split(',')[0].trim() : req.socket.remoteAddress || '';
   ip = ip.replace(/^::ffff:/, '');
   if (ip === '::1') ip = '127.0.0.1';
+  console.log('IP:', ip);
   if (!whitelistLoaded || !whitelistIPs.includes(ip)) {
     return res.status(403).send('You are not whitelisted');
   }


### PR DESCRIPTION
## Summary
- log client IP in the whitelist middleware
- document how to check the logged IP in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ebf315bc8329bf81ec9f6a00cfcf