### PR TITLE
Handle Discord message attachments

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -27,6 +27,7 @@ async function postQueue(payload, retries = 3) {
 client.on('messageCreate', async (msg) => {
   if (msg.channelId !== CHANNEL_ID) return;
   if (msg.author.bot) return;
+  const attachments = msg.attachments?.map(a => a.url) || [];
   const payload = {
     id: msg.id,
     content: msg.content,
@@ -35,7 +36,8 @@ client.on('messageCreate', async (msg) => {
     username: msg.author.username,
     displayName: msg.member ? msg.member.displayName : msg.author.username,
     avatar: msg.author.displayAvatarURL({ extension: 'png', size: 64 }),
-    roles: msg.member ? msg.member.roles.cache.filter(r => r.name !== '@everyone').map(r => r.name) : []
+    roles: msg.member ? msg.member.roles.cache.filter(r => r.name !== '@everyone').map(r => r.name) : [],
+    attachments
   };
   await postQueue(payload);
 });

--- a/public/index.html
+++ b/public/index.html
@@ -238,29 +238,33 @@
       }
 
       function escapeHtml(str) {
+        if (!str) return '';
         return str.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
       }
 
-      function formatContent(text) {
-        if (!text) return '[no content]';
+      function mediaTag(url) {
+        const lower = url.toLowerCase();
+        if (/\.(png|jpe?g|gif|webp)(?:\?.*)?$/.test(lower)) {
+          return `<img src="${url}" class="msg-media">`;
+        }
+        if (/\.(mp4|webm|ogg)(?:\?.*)?$/.test(lower)) {
+          return `<video src="${url}" class="msg-media" autoplay loop muted controls></video>`;
+        }
+        return `<a href="${url}" target="_blank">${url}</a>`;
+      }
+
+      function formatContent(text, attachments) {
         const urlRegex = /(https?:\/\/[^\s]+)/g;
-        text = escapeHtml(text);
-        return text.replace(urlRegex, url => {
-          const lower = url.toLowerCase();
-          if (/\.(png|jpe?g|gif|webp)(?:\?.*)?$/.test(lower)) {
-            return `<img src="${url}" class="msg-media">`;
-          }
-          if (/\.(mp4|webm|ogg)(?:\?.*)?$/.test(lower)) {
-            return `<video src="${url}" class="msg-media" autoplay loop muted controls></video>`;
-          }
-          return `<a href="${url}" target="_blank">${url}</a>`;
-        });
+        text = text ? escapeHtml(text) : '[no content]';
+        let html = text.replace(urlRegex, url => mediaTag(url));
+        (attachments || []).forEach(url => { html += mediaTag(url); });
+        return html;
       }
 
       function createTab(msg) {
         const div = document.createElement('div');
         div.className = 'tab';
-        const contentHtml = formatContent(msg.content);
+        const contentHtml = formatContent(msg.content, msg.attachments);
         div.innerHTML = `<div class="author"><img src="${msg.avatar || ''}" alt="avatar"><div><div class="username">${msg.username || ''}</div><div class="displayName" style="font-size:0.9em;color:#bbb">${msg.displayName || ''}</div><div class="roles">${msg.roles && msg.roles.length ? msg.roles.join(', ') : ''}</div></div></div><div class="content">${contentHtml}</div>`;
         div.style.transition = animationsEnabled ? 'transform 0.3s' : 'none';
         return div;

--- a/server.js
+++ b/server.js
@@ -54,7 +54,8 @@ function loadData() {
       username: item.username,
       displayName: item.displayName,
       avatar: item.avatar,
-      roles: item.roles
+      roles: item.roles,
+      attachments: item.attachments || []
     }));
   } catch (e) {
     return [];
@@ -71,7 +72,8 @@ function saveData(data) {
     username: item.username,
     displayName: item.displayName,
     avatar: item.avatar,
-    roles: item.roles
+    roles: item.roles,
+    attachments: item.attachments || []
   }));
   fs.writeFileSync(DATA_FILE, JSON.stringify(stripped, null, 2));
 }
@@ -80,7 +82,7 @@ let queue = loadData();
 let nextId = queue.reduce((max, m) => Math.max(max, m.id), 0) + 1;
 
 app.post('/queue', (req, res) => {
-  const { id: sourceId, content, timestamp, authorId, username, displayName, avatar, roles } = req.body || {};
+  const { id: sourceId, content, timestamp, authorId, username, displayName, avatar, roles, attachments } = req.body || {};
   if (!sourceId || !timestamp) {
     return res.status(400).json({ error: 'invalid payload' });
   }
@@ -92,7 +94,7 @@ app.post('/queue', (req, res) => {
   const existing = queue.find(m => m.label && m.content === content);
   if (existing) label = existing.label;
 
-  const item = { id: nextId++, sourceId, content, timestamp, authorId, username, displayName, avatar, roles, displayed: false };
+  const item = { id: nextId++, sourceId, content, timestamp, authorId, username, displayName, avatar, roles, attachments: Array.isArray(attachments) ? attachments : [], displayed: false };
   if (label) item.label = label;
   queue.push(item);
   try {
@@ -123,6 +125,7 @@ app.get('/next', (req, res) => {
   res.json({
     id: item.id,
     content: item.content,
+    attachments: item.attachments,
     username: item.username,
     displayName: item.displayName,
     avatar: item.avatar,
@@ -149,6 +152,7 @@ app.post('/jump', (req, res) => {
   res.json({
     id: last.id,
     content: last.content,
+    attachments: last.attachments,
     username: last.username,
     displayName: last.displayName,
     avatar: last.avatar,


### PR DESCRIPTION
## Summary
- include attachments when queueing Discord messages
- store attachments in the server queue
- add attachments to `/next` and `/jump` responses
- render attachments on the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8f4d59a083299a5ec3cf24386512